### PR TITLE
Fix building Graph behavior in Network and add tests

### DIFF
--- a/lib/PhpFlo/Network.php
+++ b/lib/PhpFlo/Network.php
@@ -294,24 +294,10 @@ class Network implements NetworkInterface
      *
      * @param mixed $graph
      * @return NetworkInterface
-     * @throws InvalidTypeException
      */
     public function boot($graph) : NetworkInterface
     {
-        switch (true) {
-            case (is_a(Graph::class, $graph)):
-                break;
-            case (is_file($graph)):
-                $graph = Graph::loadFile($graph);
-                break;
-            case (is_string($graph)):
-                $graph = Graph::loadString($graph);
-                break;
-            default:
-                throw new InvalidTypeException(
-                    "Graph has to be either a Graph object or a compatible definition file/string"
-                );
-        }
+        $graph = $this->buildGraph($graph);
 
         $graph->on(self::EVENT_ADD, [$this, 'addNode']);
         $graph->on(self::EVENT_REMOVE, [$this, 'removeNode']);
@@ -323,6 +309,32 @@ class Network implements NetworkInterface
         $this->loadGraph($graph);
 
         return $this;
+    }
+
+    /**
+     * Use appropriate strategy to build graph according to parameter type
+     *
+     * @param Graph|string $graph
+     * @return Graph
+     * @throws InvalidTypeException
+     */
+    public function buildGraph($graph) : Graph
+    {
+        if(is_a($graph, Graph::class)) {
+            return $graph;
+        }
+
+        if(is_string($graph)) {
+            if (is_file($graph)) {
+                return Graph::loadFile($graph);
+            }
+
+            return Graph::loadString($graph);
+        }
+
+        throw new InvalidTypeException(
+            "Graph has to be either a Graph object or a compatible definition file/string"
+        );
     }
 
     /**

--- a/tests/PhpFlo/GraphTest.php
+++ b/tests/PhpFlo/GraphTest.php
@@ -5,9 +5,12 @@ use PhpFlo\Graph;
 
 class GraphTest extends \PHPUnit_Framework_TestCase
 {
+    const JSON_GRAPH_FILEPATH = __DIR__.'/../../examples/linecount/count.json';
+    const FBP_GRAPH_FILEPATH = __DIR__.'/../../examples/linecount/count.fbp';
+
     public function testLoadFile()
     {
-        $graph = Graph::loadFile(__DIR__.'/../../examples/linecount/count.json');
+        $graph = Graph::loadFile(self::JSON_GRAPH_FILEPATH);
         $readFile = $graph->getNode('ReadFile');
         $this->assertEquals('ReadFile', $readFile['id']);
 

--- a/tests/PhpFlo/NetworkTest.php
+++ b/tests/PhpFlo/NetworkTest.php
@@ -1,20 +1,94 @@
 <?php
 namespace Tests\PhpFlo;
 
-use PhpFlo\Builder\ComponentFactory;
+use PhpFlo\Common\ComponentBuilderInterface;
+use PhpFlo\Common\DefinitionInterface;
+use PhpFlo\Component\Counter;
+use PhpFlo\Component\Output;
+use PhpFlo\Component\ReadFile;
+use PhpFlo\Component\SplitStr;
+use PhpFlo\Exception\InvalidTypeException;
+use PhpFlo\Graph;
 use PhpFlo\Network;
 
 class NetworkTest extends \PHPUnit_Framework_TestCase
 {
-    public function testLoadFile()
+    const JSON_GRAPH_FILEPATH = __DIR__.'/../../examples/linecount/count.json';
+    const FBP_GRAPH_FILEPATH = __DIR__.'/../../examples/linecount/count.fbp';
+
+    /**
+     * @var ComponentBuilderInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $builder;
+
+    /**
+     * @var Network
+     */
+    private $network;
+
+    public function setUp()
     {
-        $builder = new ComponentFactory();
+        $this->builder = $this->createMock(ComponentBuilderInterface::class);
+        $this->network = new Network($this->builder);
+    }
 
-        $network = new Network($builder);
-        $network
-            ->boot(__DIR__.'/../../examples/linecount/count.json');
+    public function testBuildGraphFromFile()
+    {
+        $this->assertInstanceOf(
+            Graph::class,
+            $this->network->buildGraph(GraphTest::JSON_GRAPH_FILEPATH)
+        );
+    }
 
-        $readFile = $network->getNode('ReadFile');
+    public function testBuildGraphFromGraphObject()
+    {
+        $graph = new Graph($this->createMock(DefinitionInterface::class));
+
+        $this->assertSame(
+            $graph,
+            $this->network->buildGraph($graph)
+        );
+    }
+
+    public function testBuildGraphFromString()
+    {
+        $this->assertInstanceOf(
+            Graph::class,
+            $this->network->buildGraph(file_get_contents(GraphTest::FBP_GRAPH_FILEPATH))
+        );
+    }
+
+    public function testBuildGraphFromInvalidObject()
+    {
+        $this->expectException(InvalidTypeException::class);
+        $this->network->buildGraph(new \stdClass());
+
+    }
+
+    public function testBoot()
+    {
+        $this->builder
+            ->expects($this->exactly(4))
+            ->method('build')
+            ->willReturnCallback(function($componentId) {
+               switch ($componentId) {
+                   case 'ReadFile':
+                       return new ReadFile();
+                   case 'SplitStr':
+                       return new SplitStr();
+                   case 'Counter':
+                       return new Counter();
+                   case 'Output':
+                       return new Output();
+               }
+            });
+
+        $this->assertSame(
+            $this->network,
+            $this->network->boot(GraphTest::JSON_GRAPH_FILEPATH)
+        );
+
+        $readFile = $this->network->getNode('ReadFile');
         $this->assertEquals('ReadFile', $readFile['id']);
     }
 }


### PR DESCRIPTION
Booting network from Graph object didn't work because of wrong parameters assignment order in "is_a" function. That led me to add tests to ensure trivial mistakes like this won't happen again.
I thought separating the graph construction logic would be more SRP so I create the buildGraph function but TBH it shouldn't be the Network responsibility to create a Graph, it's a perfect fit for a GraphFactory IMO.
Not sure how it would fit to the existing source code thought.

While creating tests I saw 3 improvements to make:
- Rely on the ComponentBuilderInterface instead of a concrete class for network creation in tests
- Put magic strings (example json file path) to a constant for reusability, it's in GraphTest for now but it would be better to encaspulate it in a TestFixtures file
- Fix booting from an invalid parameter that threw a TypeError because is_file() expects a string which the switch doesnt avoid so the InvalidTypeException was never thrown