### PR TITLE
Improves ComponentFactory test and fix a skipped one

### DIFF
--- a/lib/PhpFlo/Builder/ComponentFactory.php
+++ b/lib/PhpFlo/Builder/ComponentFactory.php
@@ -40,6 +40,7 @@ class ComponentFactory implements ComponentBuilderInterface
                 throw new InvalidDefinitionException("Component class {$component} not found");
             }
         }
+
         $instance = new $component();
         if (!$instance instanceof ComponentInterface) {
             throw new InvalidDefinitionException(

--- a/tests/PhpFlo/Builder/ComponentFactoryTest.php
+++ b/tests/PhpFlo/Builder/ComponentFactoryTest.php
@@ -2,6 +2,7 @@
 namespace Test\PhpFlo\Builder;
 
 use PhpFlo\Builder\ComponentFactory;
+use PhpFlo\Exception\InvalidDefinitionException;
 
 class ComponentFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -9,24 +10,24 @@ class ComponentFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $diFactory = new ComponentFactory();
 
-        $this->assertInstanceOf('PhpFlo\Builder\ComponentFactory', $diFactory);
+        $this->assertInstanceOf(ComponentFactory::class, $diFactory);
     }
 
-    /**
-     * @expectedException \PhpFlo\Exception\InvalidDefinitionException
-     * @expectedExceptionMessage Component class PhpFlo\Component\SomeVirtualComponent not found
-     */
     public function testClassNotFoundException()
     {
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('Component class PhpFlo\Component\SomeVirtualComponent not found');
+
         $diFactory = new ComponentFactory();
-        $component = $diFactory->build('SomeVirtualComponent');
+        $diFactory->build('SomeVirtualComponent');
     }
 
-    /**
-     * @expectedException \PhpFlo\Exception\InvalidDefinitionException
-     */
     public function testInvalidComponentException()
     {
-        $this->markTestIncomplete('If someone finds an easy way to mock non-existing classes in autoload: Give it a try');
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('Component stdClass doesn\'t appear to be a valid PhpFlo component');
+
+        $diFactory = new ComponentFactory();
+        $diFactory->build(\stdClass::class);
     }
 }


### PR DESCRIPTION
There is no need to dynamically register class to autoloader to throw the wanted exception, a simple FQCN does the job.

Changed expected exception annotation to the best practices equivalent methods.

Switch FQCN string to the dynamic equivalent for better refactoring flexibility.