### PR TITLE
Add PHPCS PSR2 check tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",
+        "squizlabs/php_codesniffer": "^2.3",
         "mikey179/vfsStream": "^1.6"
     },
     "autoload": {
@@ -33,5 +34,10 @@
     },
     "autoload-dev": {
         "psr-4": { "Tests\\": "tests/" }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "check-style": "phpcs -p --standard=ruleset.xml --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 lib tests",
+        "fix-style": "phpcbf -p --standard=ruleset.xml --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 lib tests"
     }
 }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="phpflo">
+    <description>The phpflo coding standard.</description>
+    <rule ref="PSR2">
+        <exclude name="Generic.Files.LineLength"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
To make sure phpflo files are strictly following PSR2 standards this PR adds the most common tool in the php ecosystem to detect coding standard errors.

I've added composer shortcuts to help anyone contributing checking their work with a simple and clear command line.

I've also excluded the 120 caracters limit per line by default as the project has some right now which didn't look to bother maintainers for now so I supposed it should be excluded. Waiting approval on this one.

This is taken from https://github.com/thephpleague/skeleton/blob/master/composer.json